### PR TITLE
[fix] devise login layout

### DIFF
--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -10,7 +10,6 @@
     height: 100vh;
     min-height: 300px;
     background-size: cover;
-    z-index: -1;
 }
 
 .jumbotron-extend:after {


### PR DESCRIPTION
deviseのログイン画面のエラーを修正しました。
原因はcard-scssのz-indexによるものでした。