### PR TITLE
fix: turbolinks

### DIFF
--- a/app/javascript/packs/users.js
+++ b/app/javascript/packs/users.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('turbolinks:load', function() {
   const tabs = document.getElementsByClassName('tabs_item');
   for(let i = 0; i < tabs.length; i++) {
     tabs[i].addEventListener('click', tabSwitch);


### PR DESCRIPTION
ページ読み込み時にタブが作動しない問題が発生したので、domcontentloadedからturbolinksに変更しました